### PR TITLE
fix: replace default port as 31007 to fit cnosdb 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import cnosdb_connector
 ```python
 from cnosdb_connector import connect
 
-conn = connect(url="http://127.0.0.1:31001/", user="root", password="")
+conn = connect(url="http://127.0.0.1:31007/", user="root", password="")
 resp = conn.execute("SHOW DATABASES")
 print(resp)
 ```
@@ -33,7 +33,7 @@ print(resp)
 ```python
 from cnosdb_connector import connect
 
-conn = connect(url="http://127.0.0.1:31001/", user="root", password="")
+conn = connect(url="http://127.0.0.1:31007/", user="root", password="")
 conn.create_database("air")
 resp = conn.list_database()
 print(resp)
@@ -44,7 +44,7 @@ print(resp)
 ```python
 from cnosdb_connector import connect
 
-conn = connect(url="http://127.0.0.1:31001/", user="root", password="")
+conn = connect(url="http://127.0.0.1:31007/", user="root", password="")
 cursor = conn.cursor()
 
 cursor.execute("SHOW DATABASES")
@@ -58,7 +58,7 @@ print(resp)
 import pandas as pd
 from cnosdb_connector import connect
 
-conn = connect(url="http://127.0.0.1:31001/", user="root", password="")
+conn = connect(url="http://127.0.0.1:31007/", user="root", password="")
 
 resp = pd.read_sql("SHOW DATABASES", conn)
 print(resp)
@@ -73,7 +73,7 @@ line0 = "test_insert,ta=a1,tb=b1 fa=1,fb=2 1"
 line1 = "test_insert,ta=a1,tb=b1 fa=3,fb=4 2"
 line2 = "test_insert,ta=a1,tb=b1 fa=5,fb=6 3"
 
-conn = connect(url="http://127.0.0.1:31001/", user="root", password="")
+conn = connect(url="http://127.0.0.1:31007/", user="root", password="")
 
 conn.create_database_with_ttl("test_database", "100000d")
 conn.switch_database("test_database")
@@ -89,7 +89,7 @@ print(resp)
 ```python
 from cnosdb_connector import connect
 
-conn = connect(url="http://127.0.0.1:31001/", user="root", password="")
+conn = connect(url="http://127.0.0.1:31007/", user="root", password="")
 
 query = "insert test_insert(TIME, column1, column2, column3, column4, column5, column6, column7) values (100, -1234, 'hello', 1234, false, 1.2, 'beijing', 'shanghai'); "
 
@@ -110,7 +110,7 @@ query = "CREATE TABLE test_insert(column1 BIGINT CODEC(DELTA),\
                                   column3 DOUBLE CODEC(GORILLA),\
                                   TAGS(column4));"
 
-conn = connect(url="http://127.0.0.1:31001/", user="root", password="")
+conn = connect(url="http://127.0.0.1:31007/", user="root", password="")
 # table schema must same with csv file
 conn.execute(query)
 

--- a/cnosdb_connector/__init__.py
+++ b/cnosdb_connector/__init__.py
@@ -6,7 +6,7 @@ def connect(**kwargs) -> CnosDBConnection:
     Keyword Arguments
     ========================================================================
     url: str
-        optional, default_value: "http://127.0.0.1:31001/"
+        optional, default_value: "http://127.0.0.1:31007/"
         description: the url to connect db server
 
     database: str

--- a/cnosdb_connector/client.py
+++ b/cnosdb_connector/client.py
@@ -15,7 +15,7 @@ error_msgs = {
 
 
 class Client:
-    def __init__(self, url: str = "http://localhost:31001/",
+    def __init__(self, url: str = "http://localhost:31007/",
                  database: str = "public",
                  user: str = "root",
                  password: str = ""):

--- a/cnosdb_connector/conn.py
+++ b/cnosdb_connector/conn.py
@@ -5,7 +5,7 @@ from .cursor import Cursor
 
 class CnosDBConnection:
     def __init__(self, **kwargs):
-        url = kwargs.get("url", "http://127.0.0.1:31001/")
+        url = kwargs.get("url", "http://127.0.0.1:31007/")
         user = kwargs.get("user", "root")
         password = kwargs.get("password", "")
         database = kwargs.get("database", "public")


### PR DESCRIPTION
According to the docs of [cnosdb-quick-start](https://github.com/cnosdb/cnosdb/blob/main/docs/quick-start.md), the default port of cnosdb is 31007 both of container and local.

So we'd better change the default port to make examples easy-to-use.